### PR TITLE
カテゴリータグのレスポンス形式の変更 ロジックの分割

### DIFF
--- a/app/api/views/question.py
+++ b/app/api/views/question.py
@@ -1,3 +1,4 @@
+from app.api.models import index
 from os import kill
 from flask import Blueprint, request, make_response, jsonify, session, abort
 from api.models import User
@@ -5,6 +6,7 @@ from api.models import (
     Index,
     IndexSchema,
     IndexCategoryTag,
+    CategorytagSchema,
     IndexCategorytagSchema,
 )
 from flask_jwt_extended import jwt_required, current_user
@@ -62,25 +64,13 @@ def getIndexList():
         indices = Index.getIndexList(request_dict)
         index_schema = IndexSchema(many=True)
         indices_list = index_schema.dump(indices)
-        categorytag_schema = IndexCategorytagSchema(many=True)
-        indices_categorytag_list = []
-
-        for indices_dict in indices_list:
-            categorytags = IndexCategoryTag.getCategoryTagList(indices_dict)
-            categorytags_list = categorytag_schema.dump(categorytags)
-            indices_dict["categorytags"] = {}
-            for categorytags_dict in categorytags_list:
-                if indices_dict["id"] == categorytags_dict["index_id"]:
-                    indices_dict["categorytags"][
-                        categorytags_dict["category_tag_id"]
-                    ] = categorytags_dict["category_name"]
-
-            indices_categorytag_list.append(indices_dict)
 
     except ValueError:
         abort(400, {"message": ValueError})
 
-    return make_response(jsonify({"code": 200, "indices": indices_categorytag_list}))
+    return make_response(
+        jsonify({"code": 200, "indices": merge_indices_categorytags(indices_list)})
+    )
 
 
 @question_router.route("/question", methods=["POST"])
@@ -158,7 +148,34 @@ def getUserIndexList():
 
         indices = Index.getUserIndexList(request_dict)
         index_schema = IndexSchema(many=True)
+        index_list = index_schema.dump(indices)
+
     except ValueError:
         abort(400, {"message": ValueError})
 
-    return make_response(jsonify({"code": 200, "indices": index_schema.dump(indices)}))
+    return make_response(
+        jsonify({"code": 200, "indices": merge_indices_categorytags(index_list)})
+    )
+
+
+##見出しのリストとカテゴリータグリストをマージする
+def merge_indices_categorytags(indices_list):
+
+    indices_categorytag_list = []
+    categorytag_schema = IndexCategorytagSchema(many=True)
+
+    for indices_dict in indices_list:
+        categorytags = IndexCategoryTag.getCategoryTagList(indices_dict)
+        categorytags_list = categorytag_schema.dump(categorytags)
+        indices_dict["categorytags"] = []
+        for categorytags_dict in categorytags_list:
+            if indices_dict["id"] == categorytags_dict["index_id"]:
+                indices_dict["categorytags"].append(
+                    {
+                        "id": categorytags_dict["category_tag_id"],
+                        "category_tag_name": categorytags_dict["category_name"],
+                    }
+                )
+        indices_categorytag_list.append(indices_dict)
+
+    return indices_categorytag_list


### PR DESCRIPTION
## 見出し一覧API /question GET

- レスポンスの形式をcategorytags配列の中に辞書型を含めるように変更
- マージロジックを分割
- ユーザーごとの見出し取得にも対応