### PR TITLE
DB構造の修正

### DIFF
--- a/app/api/models/index.py
+++ b/app/api/models/index.py
@@ -41,7 +41,8 @@ class Index(db.Model):
             else ""
         )
 
-        category_tag_filter = Index.get_category_tag_filter(category_tag_id_list)
+        if category_tag_id_list != "":
+            category_tag_filter = Index.get_category_tag_filter(category_tag_id_list)
 
         index_limit = (
             int(request_dict["index_limit"])
@@ -91,8 +92,10 @@ class Index(db.Model):
             Index.language_id == language_id,
             User.id == Index.questioner,
             Index.id == answer_count.c.index_id,
-            Index.id == category_tag_filter.c.index_id,
         )
+
+        if category_tag_id_list != "":
+            index_list = index_list.filter(Index.id == category_tag_filter.c.index_id)
 
         if include_no_answer == 3:
             index_list = index_list.filter(answer_count.c.answer_count == 0)

--- a/mysql/db/mysql_init/init.sql
+++ b/mysql/db/mysql_init/init.sql
@@ -19,8 +19,8 @@ DROP TABLE IF EXISTS favorite_indices;
 CREATE TABLE users (
     id INT PRIMARY KEY AUTO_INCREMENT,
     username varchar(20) NOT NULL,
-    email varchar(254) NOT NULL,
-    password varchar(254) NOT NULL,
+    email varchar(256) NOT NULL,
+    password varchar(255) NOT NULL,
     icon varchar(300)
 );
 
@@ -34,7 +34,7 @@ CREATE TABLE languages(
 );
 
 INSERT INTO languages VALUES
-(0, '英語'),
+(0, 'English'),
 (0, '日本語');
 
 CREATE TABLE users_languages(
@@ -57,8 +57,23 @@ CREATE TABLE communitytags(
 );
 
 INSERT INTO communitytags VALUES
-(0, '社会人'),
-(0, '学生');
+(0, 'student'),
+(0, 'office worker'),
+(0, 'engineer'),
+(0, 'hospitality industr'),
+(0, 'medical industry'),
+(0, 'financial industry'),
+(0, 'primary industry'),
+(0, 'child'),
+(0, 'teenager'),
+(0, 'adult'),
+(0, 'noughty'),
+(0, '`middle age'),
+(0, 'elderly'),
+(0, 'enthusiast'),
+(0, 'athelete'),
+(0, 'male'),
+(0, 'female');
 
 CREATE TABLE users_communitytags(
     user_id INT,
@@ -69,6 +84,14 @@ CREATE TABLE users_communitytags(
     FOREIGN KEY (community_tag_id)
         REFERENCES communitytags(id) ON DELETE CASCADE
 );
+
+INSERT INTO users_communitytags VALUES
+(1, 1),
+(1, 3),
+(1, 17),
+(2, 2),
+(2, 10),
+(2, 16);
 
 
 CREATE TABLE indices(
@@ -86,7 +109,11 @@ CREATE TABLE indices(
 
 INSERT INTO indices(id, `index`, questioner, language_id) VALUES
 (0, 'enjoy', 1, 1),
-(0, '草', 2, 2);
+(0, '草', 2, 2),
+(0, 'hoge', 2, 1),
+(0, 'Sup?', 1, 1),
+(0, '三密', 2, 2),
+(0, '台パン', 1, 2);
 
 CREATE TABLE categorytags(
     id INT PRIMARY KEY AUTO_INCREMENT,
@@ -94,18 +121,30 @@ CREATE TABLE categorytags(
 );
 
 INSERT INTO categorytags VALUES
-(0, '一般英語'),
-(0, '一般日本語');
+(0, 'slang'),
+(0, 'formal'),
+(0, 'polite'),
+(0, 'casual'),
+(0, 'offensive'),
+(0, 'intelligent'),
+(0, 'pedantic'),
+(0, 'writtern language'),
+(0, 'spoken language'),
+(0, 'poetic'),
+(0, 'proverb'),
+(0, 'obsolete'),
+(0, 'archaic'),
+(0, 'science'),
+(0, 'technical term');
 
-CREATE TABLE indices_communitytags_count(
+CREATE TABLE indices_users_communitytags(
     index_id INT,
-    community_tag_id INT,
-    count INT NOT NULL default 0,
-    PRIMARY KEY(index_id, community_tag_id),
+    user_id INT,
+    PRIMARY KEY(index_id, user_id),
     FOREIGN KEY (index_id)
         REFERENCES indices(id) ON DELETE CASCADE,
-    FOREIGN KEY (community_tag_id)
-        REFERENCES communitytags(id) ON DELETE CASCADE
+    FOREIGN KEY (user_id)
+        REFERENCES users(id) ON DELETE CASCADE
 );
 
 CREATE TABLE indices_categorytags(
@@ -117,6 +156,14 @@ CREATE TABLE indices_categorytags(
     FOREIGN KEY (category_tag_id)
         REFERENCES categorytags(id) ON DELETE CASCADE
 );
+
+INSERT INTO indices_categorytags VALUES
+(1, 8),
+(2, 1),
+(3, 1),
+(4, 4),
+(5, 6),
+(6, 5);
 
 CREATE TABLE answers(
     id INT PRIMARY KEY AUTO_INCREMENT,
@@ -135,11 +182,26 @@ CREATE TABLE answers(
 
 INSERT INTO answers(id, user_id, index_id, `definition`, origin, note) VALUES
 (0, 2, 2, '葉っぱ、おもろい', 'わからんてぃうす', 'いっぱい意味あるよ'),
-(0, 1, 1, 'to get pleasure from something', '', '');
+(0, 1, 1, 'to get pleasure from something', '', ''),
+(0, 1, 5, '集団感染防止のために避けるべきとされる密閉・密集・密接を指す。3つの「密」・三つの密とも表記され、一般に3密と略される。', '2020年（令和2年）の新型コロナウイルス感染症（COVID-19）拡大期に総理大臣官邸・厚生労働省が掲げた標語', '英語圏ではThree Cs・3Csとして普及'),
+(0, 2, 6, 'アーケードゲームなどで、主に負けた腹いせなどとして、筐体を叩くなどの行為を意味する', '', '一般的に、迷惑行為とされるほか、筐体が破損した場合には器物損壊罪の適用もありうる'),
+(0, 1, 6, 'クレーンゲームなどで景品を落とすこと', '', ''),
+(0, 2, 3, 'プログラムのサンプルコードなどで、特に意味がない、何を入れてもかまわないときに使う言葉', '', ''),
+(0, 1, 4, 'やぁ。最近どう？何かあった？', '', 'メールやSNS上でよく見かける表現');
+
+CREATE TABLE answers_infomative(
+    answer_id INT,
+    user_id INT,
+    PRIMARY KEY(answer_id , user_id),
+    FOREIGN KEY (answer_id )
+        REFERENCES answers(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id)
+        REFERENCES users(id) ON DELETE CASCADE
+);
 
 CREATE TABLE example_answer(
     id INT PRIMARY KEY AUTO_INCREMENT,
-    example_sentence varchar(200) NOT NULL,
+    example_sentence varchar(255) NOT NULL,
     answer_id INT NOT NULL,
     FOREIGN KEY (answer_id)
         REFERENCES answers(id) ON DELETE CASCADE
@@ -147,7 +209,8 @@ CREATE TABLE example_answer(
 
 INSERT INTO example_answer VALUES
 (0, 'おもしろすぎわろたwww', 1),
-(0, 'We enjoyed our dinner.', 2);
+(0, 'We enjoyed our dinner.', 2),
+(0, '３密を意識して過ごす。', 5);
 
 CREATE TABLE favorite_indices(
     user_id INT NOT NULL,


### PR DESCRIPTION
・見出しコミュニティタグカウントテーブル→見出しユーザーコミュニティタグテーブル　comunity_tag_id countを削除 user_idの追加

・見出しテーブル　frequently_used_count 削除　→ 保留

・回答テーブル　infomative_count を削除 → 保留

・回答役に立つテーブルの追加　answer_id user_id

初期データの追加

文字数制限
ユーザー名: 20文字
メールアドレス: 256文字
見出し: 50文字
回答-定義: 1000文字
回答: 由来: 1000文字
回答-備考: 255文字
回答-例文: 255文字
カテゴリタグ名: 30文字
コミュニティタグ名: 30文字
言語名: 30文字