### PR TITLE
ユーザー情報関連のAPIにコミュニティタグを追加

### DIFF
--- a/app/api/models/__init__.py
+++ b/app/api/models/__init__.py
@@ -8,6 +8,12 @@ from .categorytag import (
     IndexCategoryTag,
     IndexCategorytagSchema,
 )
+from .community_tag import (
+    CommunityTag,
+    UserCommunityTag,
+    CommunityTagSchema,
+    UserCommunityTagSchema,
+)
 from .example_answer import ExampleAnswer, ExampleAnswerSchema
 from .language import Language, UserLanguage, LanguageSchema, UserLanguageSchema
 from .favorite_index import FavoriteIndex, FavoriteIndexSchema

--- a/app/api/models/community_tag.py
+++ b/app/api/models/community_tag.py
@@ -1,0 +1,122 @@
+import re
+from api.database import db, ma
+from sqlalchemy.ext.declarative import *
+from sqlalchemy.orm import relationship
+from sqlalchemy import *
+from flask import abort
+
+
+class CommunityTag(db.Model):
+    __tablename__ = "communitytags"
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    name = db.Column(db.String(30), nullable=False)
+
+    def __repr__(self):
+        return "<communitytags %r>" % self.name
+
+    def getCommunityTagList():
+
+        community_tag_list = (
+            db.session.query(
+                CommunityTag.id, CommunityTag.name.label("community_tag_name")
+            )
+            .order_by(asc(CommunityTag.id))
+            .all()
+        )
+
+        if community_tag_list is None:
+            return []
+        else:
+            return community_tag_list
+
+
+class UserCommunityTag(db.Model):
+    __tablename__ = "users_communitytags"
+
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), primary_key=True)
+    community_tag_id = db.Column(
+        db.Integer, db.ForeignKey("communitytags.id"), primary_key=True
+    )
+
+    def __repr__(self):
+        return "<users_communitytags %r>" % self.user_id, self.community_tag_id
+
+    def getCommunityTagList(user):
+
+        user_id = user["id"]
+
+        user_community_tag_list = (
+            db.session.query(
+                UserCommunityTag.user_id,
+                UserCommunityTag.community_tag_id,
+                CommunityTag.name.label("community_tag_name"),
+            )
+            .join(
+                CommunityTag,
+                UserCommunityTag.community_tag_id == CommunityTag.id,
+            )
+            .filter(
+                UserCommunityTag.user_id == user_id,
+            )
+            .all()
+        )
+
+        if user_community_tag_list is None:
+            return []
+        else:
+            return user_community_tag_list
+
+    def editCommunityTag(request_dict):
+
+        user_id = request_dict["user_id"]
+        community_tag_id_list = request_dict["community_tags"]
+
+        for community_tag in community_tag_id_list:
+            community_tag_list = (
+                db.session.query(CommunityTag)
+                .filter(CommunityTag.id == community_tag)
+                .all()
+            )
+            if len(community_tag_list) == 0:
+                return abort(400, {"message": "category_tag does not exists"})
+
+        # ユーザーコミュニティタグのアップデート
+        db.session.query(UserCommunityTag).filter(
+            UserCommunityTag.user_id == user_id
+        ).delete(synchronize_session="fetch")
+
+        for community_tag in community_tag_id_list:
+            record = UserCommunityTag(user_id=user_id, community_tag_id=community_tag)
+            db.session.add(record)
+
+        db.session.flush()
+        db.session.commit()
+
+        update_users_community_tag_list = (
+            db.session.query(
+                CommunityTag.id,
+                CommunityTag.name.label("community_tag_name"),
+            )
+            .join(
+                UserCommunityTag, UserCommunityTag.community_tag_id == CommunityTag.id
+            )
+            .filter(UserCommunityTag.user_id == user_id)
+            .all()
+        )
+
+        return update_users_community_tag_list
+
+
+class CommunityTagSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = CommunityTag
+        load_instance = True
+        fields = ("id", "community_tag_name")
+
+
+class UserCommunityTagSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = UserCommunityTag
+        load_instance = True
+        fields = ("user_id", "community_tag_id", "community_tag_name")

--- a/app/api/models/user.py
+++ b/app/api/models/user.py
@@ -2,6 +2,7 @@ import re
 import base64
 import os
 from .language import UserLanguage
+from .community_tag import UserCommunityTag
 from flask import abort, jsonify
 from sqlalchemy.sql.functions import user
 from sqlalchemy.dialects import mysql
@@ -53,6 +54,13 @@ class User(db.Model):
         # ユーザー言語の登録
         for language in request_dict["languages"]:
             record = UserLanguage(user_id=user_id, language_id=int(language))
+            db.session.add(record)
+
+        # ユーザーコミュニティの登録
+        for community_tag in request_dict["community_tags"]:
+            record = UserCommunityTag(
+                user_id=user_id, community_tag_id=int(community_tag)
+            )
             db.session.add(record)
 
         db.session.flush()
@@ -126,6 +134,9 @@ class User(db.Model):
             for language in request_dict["languages"]:
                 record = UserLanguage(user_id=id, language_id=language)
                 db.session.add(record)
+
+        if request_dict["community_tags"] != "":
+            UserCommunityTag.editCommunityTag(request_dict)
 
         db.session.flush()
         db.session.commit()

--- a/mysql/db/mysql_init/init.sql
+++ b/mysql/db/mysql_init/init.sql
@@ -68,7 +68,7 @@ INSERT INTO communitytags VALUES
 (0, 'teenager'),
 (0, 'adult'),
 (0, 'noughty'),
-(0, '`middle age'),
+(0, 'middle age'),
 (0, 'elderly'),
 (0, 'enthusiast'),
 (0, 'athelete'),


### PR DESCRIPTION
### ユーザー登録API /signup
- リクエストにcommunity_tagsを追加　配列で送信するとユーザーに紐づいたcommunity_tagを登録
### ユーザー情報変更API /user/edit
- リクエストにcommunity_tagsを追加　配列で送信するとユーザーに紐づいたcommunity_tagを変更
### ユーザーログインAPI /login
- レスポンスオブジェクトにcommunity_tagsを追加
### ログインユーザー情報取得API /whoami
- レスポンスオブジェクトにcommunity_tagsを追加