### PR TITLE
APIコンテナ起動時にAPIを立ち上げる

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     tty: true
     volumes:
       - ./app:/app
+    command: ['python', 'app.py']
   whatisgrass_mysql:
     container_name: whatisgrass-mysql
     image: mysql:8.0


### PR DESCRIPTION
Closes #34 

## 概要
APIコンテナ起動時に`python3`が走ってただけだったので`python app.py`が走るように変更しました。