### PR TITLE
Fix クッキーつかない問題

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -16,7 +16,7 @@ def create_app():
     app.config["JSON_AS_ASCII"] = False
 
     # CORS対応
-    CORS(app)
+    CORS(app, supports_credentials=True)
 
     app.config.from_object("config.Config")
     db.init_app(app)

--- a/app/config.py
+++ b/app/config.py
@@ -14,7 +14,8 @@ class SystemConfig:
     # JWT署名鍵
     JWT_SECRET_KEY = const.JWT_SECRET_KEY
     JWT_TOKEN_LOCATION = ["headers", "cookies"]
-    JWT_COOKIE_SECURE = False
+    JWT_COOKIE_SAMESITE="None"
+    JWT_COOKIE_SECURE = True
     JWT_ACCESS_TOKEN_EXPIRES = timedelta(hours=72)
 
 


### PR DESCRIPTION
## 内容
ログインしてもCookieがつかなかった問題を解決しました。

## 変更点
- Set-CookieのSame-Site属性が設定されたいなくて"Lax"になっていて、クロスサイト前提の設計をしてるので"None"に変更、それに伴ってSecure属性も追加しました。
- Flask-CORSの設定でaccess-control-allow-credentialsヘッダーがセットされてなかったので追加しました。
