### PR TITLE
Fix 見出し取得APIが配列を返すバグ

### DIFF
--- a/app/api/models/index.py
+++ b/app/api/models/index.py
@@ -136,13 +136,10 @@ class Index(db.Model):
                 Index.id == answer_count.c.index_id,
                 Index.id == Index.id == index_id,
             )
-            .all()
+            .one()
         )
 
-        if index == null:
-            return []
-        else:
-            return index
+        return index
 
     def getUserIndexList(request_dict):
         # リクエストから取得

--- a/app/api/views/question.py
+++ b/app/api/views/question.py
@@ -1,5 +1,6 @@
 from os import kill
 from flask import Blueprint, request, make_response, jsonify, session, abort
+from sqlalchemy.orm.exc import NoResultFound
 from api.models import User
 from api.models import (
     Index,
@@ -96,15 +97,17 @@ def getIndex():
         if contents.get("index_id") is None or contents.get("index_id") == "":
             abort(400, {"message": "index_id is required"})
 
-        indices = Index.getIndex(contents.get("index_id"))
-        index_schema = IndexSchema(many=True)
-        indices_list = index_schema.dump(indices)
+        row_index = Index.getIndex(contents.get("index_id"))
+        index_schema = IndexSchema()
+        index = index_schema.dump(row_index)
 
     except ValueError:
         abort(400, {"message": "get failed"})
+    except NoResultFound:
+        abort(400, {"message": "index not found"})
 
     return make_response(
-        jsonify({"code": 200, "indices": merge_indices_categorytags(indices_list)})
+        jsonify({"code": 200, "index": merge_index_categorytags(index)})
     )
 
 


### PR DESCRIPTION
#44 
## 概要
見出し取得APIがindices配列を返してたのでindexオブジェクトを返却するように修正しました。

## やったこと
- IndexモデルのgetIndexがリストを取得してたのを1つだけ取得するように変更しました
- 見出しを ` { index: Index } `の形で返すように変更しました。

## 備考
- Indexが見つからなかった時に空配列を返していましたが、1つだけ取得するように変更したことでNoResultFound例外が投げられるようになりました。viewsのgetIndexでキャッチしています。
- 見出しを返す時にカテゴリタグをマージしている処理が見出しリストを受けとることしかできませんでした。1つだけ取得するように変更したことでリストではなくなったので、見出しとカテゴリタグを紐づける部分を抽出したメソッドを作りました。