### PR TITLE
Fix サービス業のタイポ

### DIFF
--- a/mysql/db/mysql_init/init.sql
+++ b/mysql/db/mysql_init/init.sql
@@ -75,7 +75,7 @@ INSERT INTO communitytags VALUES
 (0, 'student'),
 (0, 'office worker'),
 (0, 'engineer'),
-(0, 'hospitality industr'),
+(0, 'hospitality industry'),
 (0, 'medical industry'),
 (0, 'financial industry'),
 (0, 'primary industry'),


### PR DESCRIPTION
Closes #47 

## 内容
mysqlに事前に入ってるデータでコミュニティタグのサービス業にタイポがありました。
フロントで英語に対応した日本語に翻訳して表示しているので正しく動くように直しておきました。