### PR TITLE
Fix コミュニティタグタグズになってたバグ

### DIFF
--- a/app/api/views/communitytag.py
+++ b/app/api/views/communitytag.py
@@ -25,4 +25,4 @@ def getCommunityTagList():
     except ValueError:
         abort(400, {"message": "get failed"})
 
-    return make_response(jsonify({"code": 200, "communitytag_tags": communitytag_list}))
+    return make_response(jsonify({"code": 200, "community_tags": communitytag_list}))


### PR DESCRIPTION
Closes #49 

## 概要
コミュニティタグ取得APIの返却値が`communitytag_tags`になってたので`community_tags`に変更しました。