### PR TITLE
Fix 質問投稿の返答が安定しないバグ

### DIFF
--- a/app/api/models/index.py
+++ b/app/api/models/index.py
@@ -396,7 +396,6 @@ class Index(db.Model):
 
     def registIndex(indices):
         record = Index(
-            id=0,
             index=indices["index"],
             questioner=indices["questioner"],
             language_id=indices["language_id"],
@@ -407,11 +406,7 @@ class Index(db.Model):
         db.session.flush()
         db.session.commit()
 
-        response = db.session.execute(
-            "SELECT * from indices WHERE id = last_insert_id();"
-        )
-
-        return response
+        return record
 
     def get_answer_count():
         # 回答者数を取得するためのクエリ

--- a/app/api/views/question.py
+++ b/app/api/views/question.py
@@ -136,11 +136,11 @@ def registIndex():
 
     try:
         index = Index.registIndex(indexData)
-        index_schema = IndexSchema(many=True)
+        index_schema = IndexSchema()
     except ValueError:
         abort(400, {"message": "post failed"})
 
-    return make_response(jsonify({"code": 201, "index": index_schema.dump(index)[0]}))
+    return make_response(jsonify({"code": 201, "index": index_schema.dump(index)}))
 
 
 # ユーザー見出し一覧API


### PR DESCRIPTION
## 概要
質問投稿APIを叩くと
```
File "/app/api/views/question.py", line 143, in registIndex
     return make_response(jsonify({"code": 201, "index": index_schema.dump(index)[0]}))
IndexError: list index out of range
```
でサーバーが落ちたり落ちなかったりしてたので実装を見ると、insertした後にlast_insert_id()でselectし直してたので条件によっては求めてるindexが取れないことがあったのかもしれません。
確実な再現方法はわかってません。というより時間がないのでちゃんと調べてません。よくわかってないのでissueも書いてません。

とりあえずauto_incrementなidはSQLAlchemyが埋めてくれるので、それをそのまま返した方が確実に動くと思って修正しました。