### PR TITLE
Fix ユーザー登録が安定しないバグ

### DIFF
--- a/app/api/models/user.py
+++ b/app/api/models/user.py
@@ -37,19 +37,16 @@ class User(db.Model):
         if user is not None:
             return abort(400, {"message": "user is already registered"})
 
-        record = User(
+        new_user = User(
             username=username,
             email=email,
             password=password,
         )
 
-        db.session.add(record)
+        db.session.add(new_user)
         db.session.flush()
 
-        user = db.session.execute("SELECT * from users WHERE id = last_insert_id();")
-
-        for get_user_id in user:
-            user_id = get_user_id.id
+        user_id = new_user.id
 
         # ユーザー言語の登録
         for first_language in request_dict["first_languages"]:
@@ -73,14 +70,7 @@ class User(db.Model):
         db.session.flush()
         db.session.commit()
 
-        response = db.session.execute(
-            "SELECT * from users WHERE id = last_insert_id();"
-        )
-
-        if response is None:
-            return []
-        else:
-            return response
+        return new_user
 
     def loginUser(request_dict):
         email = request_dict["email"]

--- a/app/api/models/user.py
+++ b/app/api/models/user.py
@@ -70,7 +70,15 @@ class User(db.Model):
         db.session.flush()
         db.session.commit()
 
-        return new_user
+        access_token = access_token = create_access_token(identity=new_user)
+        new_user_with_token = {
+            "id": new_user.id,
+            "username": new_user.username,
+            "email": new_user.email,
+            "access_token": access_token,
+        }
+
+        return new_user_with_token
 
     def loginUser(request_dict):
         email = request_dict["email"]

--- a/app/api/views/user.py
+++ b/app/api/views/user.py
@@ -86,10 +86,13 @@ def postUserSignup():
         user = User.registUser(userData)
         user_schema = UserSchema()
         dumped_user = user_schema.dump(user)
+
+        response = jsonify({"code": 201, "user": merge_user_list([dumped_user])})
+        set_access_cookies(response, user["access_token"])
     except ValueError:
         abort(400, {"message": "sigunup failed"})
 
-    return make_response(jsonify({"code": 201, "user": merge_user_list([dumped_user])}))
+    return make_response(response)
 
 
 @user_router.route("/login", methods=["POST"])

--- a/app/api/views/user.py
+++ b/app/api/views/user.py
@@ -84,12 +84,12 @@ def postUserSignup():
 
     try:
         user = User.registUser(userData)
-        user_schema = UserSchema(many=True)
-        user_list = user_schema.dump(user)
+        user_schema = UserSchema()
+        dumped_user = user_schema.dump(user)
     except ValueError:
         abort(400, {"message": "sigunup failed"})
 
-    return make_response(jsonify({"code": 201, "user": merge_user_list(user_list)}))
+    return make_response(jsonify({"code": 201, "user": merge_user_list([dumped_user])}))
 
 
 @user_router.route("/login", methods=["POST"])


### PR DESCRIPTION
## 概要
#54 に近いバグだと思うのですが、ユーザー登録APIも落ちたり通ったりしてたので直しました。

実装の意図はわからないのですが、よくわからないタイミングで`last_insert_id()`を使ってselectしてたり、怪しかったので、SQLAlchemyがセットしてくれるidを使うようにしました。

こちらはmysqlのデータが空(コンテナ立てた直後)の状態で叩くと確定で落ちるっぽいです。他の条件はちゃんと調べてません。
時間ないのでissueも書いてません。