### PR TITLE
Fix ユーザーオブジェクトのコミュニティタグの名前

### DIFF
--- a/app/api/views/user.py
+++ b/app/api/views/user.py
@@ -220,7 +220,7 @@ def getLoginUser():
         user["community_tags"].append(
             {
                 "id": UserCommunityTagDict["community_tag_id"],
-                "community": UserCommunityTagDict["community_tag_name"],
+                "community_tag_name": UserCommunityTagDict["community_tag_name"],
             }
         )
     return make_response(jsonify({"code": 201, "user": user}))
@@ -267,7 +267,7 @@ def merge_user_list(user_list):
                 user_dict["community_tags"].append(
                     {
                         "id": community_tag_dict["community_tag_id"],
-                        "community": community_tag_dict["community_tag_name"],
+                        "community_tag_name": community_tag_dict["community_tag_name"],
                     }
                 )
         merge_user_list.append(user_dict)


### PR DESCRIPTION
Closes #56 

## 概要
ユーザーオブジェクトのコミュニティタグの名前が`community`になってたのを仕様書通り`community_tag_name`に変えておきました。