### PR TITLE
Fix ユーザー見出し一覧APIが400を返すバグ

### DIFF
--- a/app/api/models/index.py
+++ b/app/api/models/index.py
@@ -145,7 +145,7 @@ class Index(db.Model):
     def getUserIndexList(request_dict):
         # リクエストから取得
         sort = int(request_dict["sort"]) if request_dict["sort"] is not None else 1
-        language_id = request_dict["language_id"]
+        language_id = request_dict.get("language_id")
         include_no_answer = (
             int(request_dict["include_no_answer"])
             if request_dict["include_no_answer"] is not ""
@@ -191,11 +191,13 @@ class Index(db.Model):
             )
 
         index_list = index_list.filter(
-            Index.language_id == language_id,
             User.id == Index.questioner,
             User.id == user_id,
             Index.id == answer_count.c.index_id,
         )
+
+        if language_id == None:
+          index_list = index_list.filter(Index.language_id == language_id)
 
         if include_no_answer == 3:
             index_list = index_list.filter(answer_count.c.answer_count == 0)

--- a/app/api/models/index.py
+++ b/app/api/models/index.py
@@ -191,7 +191,6 @@ class Index(db.Model):
             )
 
         index_list = index_list.filter(
-            Index.index.contains(f"{keyword}"),
             Index.language_id == language_id,
             User.id == Index.questioner,
             User.id == user_id,

--- a/app/api/views/question.py
+++ b/app/api/views/question.py
@@ -178,14 +178,6 @@ def getUserIndexList():
         ):
             request_dict["index_limit"] = contents.get("index_limit")
 
-        if (
-            contents.get("language_id") is not None
-            and contents.get("language_id") != ""
-        ):
-            request_dict["language_id"] = contents.get("language_id")
-        else:
-            abort(400, {"message": "language_id is required"})
-
         indices = Index.getUserIndexList(request_dict)
         index_schema = IndexSchema(many=True)
         index_list = index_schema.dump(indices)
@@ -194,7 +186,7 @@ def getUserIndexList():
         abort(400, {"message": "get failed"})
 
     return make_response(
-        jsonify({"code": 200, "indices": merge_indices_categorytags(index_list)[0]})
+        jsonify({"code": 200, "indices": merge_indices_categorytags(index_list)})
     )
 
 


### PR DESCRIPTION
## 概要
ユーザー見出し一覧APIが400を返すバグを解消しました。

## やったこと
- ユーザー見出し一覧APIにはkeywordのアトリビュートはないのですが、keywordを読もうとして落ちてたので修正しました。
- ユーザー見出し一覧APIはlanguage_idがオプショナルで、ない場合は全ての言語になる仕様なのですが、language_idが必須になってたので修正しました。

## 備考
とりあえず400しか返さないAPIだとデモの時困るので400が変えるバグは取ったのですが、クエリのロジックが怪しい気がします。質問して、ユーザー見出し一覧APIを叩いても空配列が帰ってきました。これについては気が向いたらIsuueを出します。