### PR TITLE
Fix 回答投稿APIが落ちてたバグ

### DIFF
--- a/app/api/models/answer.py
+++ b/app/api/models/answer.py
@@ -150,7 +150,6 @@ class Answer(db.Model):
 
         # answerの登録処理
         record = Answer(
-            id=0,
             user_id=1,
             index_id=answer["index_id"],
             definition=answer["definition"],
@@ -163,12 +162,8 @@ class Answer(db.Model):
         db.session.add(record)
         db.session.flush()
         db.session.commit()
-        answers_query = db.session.execute(
-            "SELECT * from answers WHERE id = last_insert_id();"
-        )
 
-        for get_answer_id in answers_query:
-            return int(get_answer_id.id)
+        return record
 
     def makeResponseAnswer(answer_id):
 

--- a/app/api/requests/answer.py
+++ b/app/api/requests/answer.py
@@ -99,20 +99,21 @@ class ValidateAnswer:
                 "SELECT id from categorytags where id = %s;"
                 % request_dict["category_tag_id"]
             )
-            categorytag_id = 0
+            categorytag_ids = []
             for get_categorytag_id in categorytag_query:
-                categorytag_id = get_categorytag_id.id
-                dict = {
-                    "category_tag_id": {
-                        "allowed": [categorytag_id],
-                        "required": True,
-                        "empty": False,
-                        "nullable": False,
-                        "coerce": int,
-                    }
-                }
-                schema.append(dict)
+                categorytag_ids.append(get_categorytag_id.id)
 
+            category_schema = {
+                "category_tag_id": {
+                    "allowed": categorytag_ids,
+                    "required": True,
+                    "empty": False,
+                    "nullable": False,
+                    "coerce": int,
+                }
+            }
+
+            schema.update(category_schema)
         # バリデータを作成
         v = Validator(schema)
 

--- a/app/api/views/answer.py
+++ b/app/api/views/answer.py
@@ -100,7 +100,7 @@ def registAnswer():
     except ValueError:
         abort(400, {"message": "value is invalid"})
 
-    return make_response(jsonify({"code": 201, "answer": response_query}))
+    return make_response(jsonify({"code": 201, "answer": response_query[0]}))
 
 
 # 回答役に立つカウントアップAPI

--- a/app/api/views/answer.py
+++ b/app/api/views/answer.py
@@ -93,9 +93,9 @@ def registAnswer():
         abort(400, {"message": "parameter is a required"})
 
     try:
-        answer_id = Answer.registAnswer(answerData)
-        ExampleAnswer.registExampleAnswer(answerData["example"], answer_id)
-        response_query = Answer.makeResponseAnswer(answer_id)
+        answer = Answer.registAnswer(answerData)
+        ExampleAnswer.registExampleAnswer(answerData["example"], answer.id)
+        response_query = Answer.makeResponseAnswer(answer.id)
 
     except ValueError:
         abort(400, {"message": "value is invalid"})


### PR DESCRIPTION
## 概要
回答投稿APIが落ちてたので直しました。

## やったこと
- バリデーションをする際によくわからないバリデータースキーマを錬金しようとして落ちてたっぽいので、「カテゴリタグの存在確認のためにクエリ送って、それを元に`allowed`の値を変えたい」のだと勝手に解釈して修正しました。
- 登録後にanswer_idがうまく入ったり、入らなかったりしてたので、安定させました。